### PR TITLE
docs: add MCP tool selection decision tree cheatsheet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ over built-in tools.**
 If you see a message like `Index not found. Run 'rfx index' to build the cache first`, run `mcp__reflex__index_project`
 immediately, and once the indexing completes, run the previously failed tool again.
 
+**Not sure which MCP tool to use?** See the [MCP Tool Selection Cheatsheet](./docs/mcp-tool-cheatsheet.md) for a decision tree organized by goal: finding locations, definitions, file dependencies, and codebase structure.
+
 ## Project Overview
 **Reflex** is a local-first, full-text code search engine written in Rust. It's a fast, deterministic replacement for Sourcegraph Code Search, designed specifically for AI coding workflows and automation.
 

--- a/README.md
+++ b/README.md
@@ -1,703 +1,258 @@
 # Reflex
 
-**Local-first code search engine with full-text search, symbol extraction, and dependency analysis for AI coding workflows**
+**Sub-100ms local code search — CLI, scripts, and AI agents**
 
-Reflex is a code search engine designed for developers and AI coding assistants. It combines trigram indexing for full-text search with Tree-sitter parsing for symbol extraction and static analysis for dependency tracking. Unlike symbol-only tools, Reflex finds **every occurrence** of patterns, function calls, variable usage, comments, and more with deterministic, repeatable results.
+Reflex is a local-first, full-text code search engine. Use it from the command line, pipe it into scripts, or connect it to AI coding assistants (Claude Code, Cursor, and any MCP-compatible tool) for instant symbol lookup, dependency analysis, and codebase exploration — fully offline, fully deterministic, no cloud required.
 
 [![CI](https://github.com/reflex-search/reflex/actions/workflows/ci.yml/badge.svg)](https://github.com/reflex-search/reflex/actions/workflows/ci.yml)
 [![Tests](https://img.shields.io/badge/tests-347%20passing-brightgreen)]()
 [![License](https://img.shields.io/badge/license-MIT-blue)]()
-[![gitcgr](https://gitcgr.com/badge/reflex-search/reflex.svg)](https://gitcgr.com/reflex-search/reflex)
+[![MCP Quickstart](https://img.shields.io/badge/MCP-quickstart-blue)](docs/ai-agent-integration.md)
 
-## ✨ Features
+---
 
-- **🔍 Complete Coverage**: Find every occurrence, not just symbol definitions
-- **⚡ Fast Queries**: Trigram indexing with memory-mapped I/O for efficient search
-- **🎯 Symbol-Aware**: Runtime tree-sitter parsing for precise symbol filtering
-- **🖥️ Interactive Mode**: Live TUI for exploring code with instant search and filters
-- **🔄 Incremental**: Only reindexes changed files (blake3 hashing)
-- **🌍 Multi-Language**: Rust, TypeScript/JavaScript, Vue, Svelte, PHP, Python, Go, Java, C, C++, C#, Ruby, Kotlin, Zig
-- **🤖 AI Query Assistant**: Natural language search with `rfx ask` (OpenAI, Anthropic, OpenRouter, or any OpenAI-compatible endpoint such as LMStudio, Ollama, llama.cpp, or litellm)
-- **📡 MCP Support**: Model Context Protocol server for AI assistants
-- **📦 Local-First**: Fully offline, all data stays on your machine
-- **🎨 Regex Support**: Trigram-optimized regex search
-- **🌳 AST Queries**: Structure-aware search with Tree-sitter
-- **🔒 Deterministic**: Same query → same results (no probabilistic ranking)
-- **📊 Pulse**: Auto-generated digest, wiki, and architecture map from structural index data
+## Quick start
 
-## 🚀 Quick Start
-
-### Installation
+### 1. Install
 
 ```bash
 # Via NPM
 npm install -g reflex-search
 
-# Or via cargo
+# Or via Cargo
 cargo install reflex-search
 ```
 
-**Important Setup Notes:**
-- Run `rfx` commands from the root of your project directory
-- Add `.reflex/` to your `.gitignore` file to exclude the search index from version control
-
-### Basic Usage
+### 2. Index and search
 
 ```bash
-# Index your codebase
+# From your project root
 rfx index
 
-# Full-text search (finds all occurrences)
+# Full-text search
 rfx query "extract_symbols"
 
-# Symbol-only search (definitions only)
-rfx query "extract_symbols" --symbols
+# Symbol definitions only
+rfx query "CacheManager" --symbols
 
-# Filter by language and symbol kind
-rfx query "parse" --lang rust --kind function --symbols
-
-# Include dependency information (imports)
-rfx query "MyStruct" --dependencies
-
-# Regex search
-rfx query "fn.*test" --regex
-
-# Paths-only mode (for piping to other tools)
-vim $(rfx query "TODO" --paths)
-
-# Export as JSON for AI agents
-rfx query "unwrap" --json --limit 10
+# JSON output for scripting
+rfx query "TODO" --json --limit 20
 ```
 
-## 🤖 AI Query Assistant
+### 3. (Optional) Connect to an AI agent via MCP
 
-Don't want to remember search syntax? Use `rfx ask` to translate natural language questions into `rfx query` commands.
-
-### Setup
-
-First-time setup requires configuring an AI provider. Reflex supports OpenAI, Anthropic, OpenRouter, and any **OpenAI-compatible endpoint** (LMStudio, Ollama, llama.cpp server, vLLM, litellm, etc.). This configuration is shared by `rfx ask` and `rfx pulse`.
-
-```bash
-# Interactive configuration wizard (recommended)
-rfx llm config
-
-# Check current configuration
-rfx llm status
-```
-
-This will guide you through:
-- Selecting an AI provider
-- Entering your API key (or base URL for self-hosted endpoints)
-- Choosing a model (optional)
-
-Configuration is saved to `~/.reflex/config.toml`:
-
-```toml
-[semantic]
-provider = "openai"  # or anthropic, openrouter, openai-compatible
-
-[credentials]
-openai_api_key = "sk-..."
-openai_model = "gpt-4o-mini"  # optional
-```
-
-#### Self-hosted / OpenAI-compatible endpoints
-
-Point Reflex at any server that implements the OpenAI Chat Completions schema — for example a local LMStudio, Ollama, llama.cpp, vLLM instance, or a litellm proxy. The API key is optional for keyless local servers.
-
-```toml
-[semantic]
-provider = "openai-compatible"
-
-[credentials]
-openai_compatible_base_url = "http://localhost:1234/v1"
-openai_compatible_model = "qwen2.5-coder-32b-instruct"
-# openai_compatible_api_key = "sk-..."   # optional; omit for local servers
-```
-
-The same settings can be supplied via env vars: `OPENAI_COMPATIBLE_BASE_URL`, `OPENAI_COMPATIBLE_API_KEY`, `REFLEX_PROVIDER=openai-compatible`, `REFLEX_MODEL=…`.
-
-### Usage
-
-There are two ways to use `rfx ask`: 
-
-1) Interactive mode
-
-Interactive chat mode with conversation history. This mode uses `--agentic` and `--answer` under the hood.
-
-```bash
-rfx ask
-```
-
-2) CLI-only mode
-
-One-shot, non-conversational commands that return results directly via CLI.
-
-```bash
-# Ask a question (generates and executes rfx query commands, only returns query results)
-rfx ask "Find all TODOs in Rust files"
-
-# Use a specific provider
-rfx ask "Show me error handling code" --provider openrouter
-
-# Use a local OpenAI-compatible server (e.g. LMStudio)
-rfx ask "Show me error handling code" --provider openai-compatible
-
-# Agentic mode (multi-step reasoning with automatic context gathering)
-rfx ask "How does authentication work?" --agentic
-
-# Get a conversational answer based on search results
-rfx ask "What does the indexer module do?" --answer
-```
-
-**How it works:**
-1. Your natural language question is sent to an LLM
-2. The LLM generates one or more `rfx query` commands
-3. You review and confirm (or use `--execute` to auto-run)
-4. Results are displayed as normal search output
-
-**Agentic mode** (`--agentic`) enables multi-step reasoning where the LLM can:
-- Gather context by running multiple searches
-- Refine queries based on initial results
-- Iteratively explore the codebase
-- Generate comprehensive answers with `--answer`
-
-## 📋 Command Reference
-
-### `rfx index`
-
-Build or update the search index.
-
-```bash
-rfx index [OPTIONS]
-
-Options:
-  --force              Force full reindex (ignore incremental)
-  --languages <LANGS>  Limit to specific languages (comma-separated)
-
-Subcommands:
-  status               Show background symbol indexing status
-  compact              Compact cache (remove deleted files, reclaim space)
-```
-
-### `rfx query`
-
-Search the codebase with CLI or interactive TUI mode.
-
-**Interactive Mode (TUI):**
-```bash
-# Launch interactive mode (no pattern required)
-rfx query
-
-# Features:
-# - Live search with instant results
-# - Toggle filters: symbols-only, regex, language
-# - Navigate results with keyboard (j/k, arrows)
-# - Open files in $EDITOR (press 'o')
-# - Query history with Ctrl+P/Ctrl+N
-# - Press '?' for help, 'q' to quit
-```
-
-**CLI Mode:**
-
-Run `rfx query --help` for full options.
-
-**Key Options:**
-- `--symbols, -s` - Symbol-only search (definitions, not usage)
-- `--regex, -r` - Treat pattern as regex
-- `--lang <LANG>` - Filter by language
-- `--kind <KIND>` - Filter by symbol kind (function, class, struct, etc.)
-- `--dependencies` - Include dependency information (supports: Rust, TypeScript, JavaScript, Python, Go, Java, C, C++, C#, PHP, Ruby, Kotlin)
-- `--paths, -p` - Return only file paths (no content)
-- `--json` - Output as JSON
-- `--limit <N>` - Limit number of results
-- `--timeout <SECS>` - Query timeout (default: 30s)
-
-**Examples:**
-```bash
-# Find function definitions named "parse"
-rfx query "parse" --symbols --kind function
-
-# Find test functions using regex
-rfx query "fn test_\w+" --regex
-
-# Search Rust files only
-rfx query "unwrap" --lang rust
-
-# Get paths of files with TODOs
-rfx query "TODO" --paths
-
-# Include import information
-rfx query "Config" --symbols --dependencies
-```
-
-### `rfx mcp`
-
-Start as an MCP (Model Context Protocol) server for AI coding assistants.
+Add this to your Claude Code MCP configuration (`~/.claude/claude_desktop_config.json`):
 
 ```json
 {
   "mcpServers": {
     "reflex": {
       "command": "rfx",
-      "args": ["mcp"],
-      "env": {},
-      "disabled": false
+      "args": ["mcp"]
     }
   }
 }
 ```
 
-**Error Handling:**
+Your AI assistant can now call `search_code`, `find_references`, `get_dependencies`, and more.
 
-If any MCP tool returns an error about a missing or stale index (e.g., "Index not found. Run 'rfx index' to build the cache first."), the AI agent should:
+> See [Claude Code + Reflex MCP Quickstart](docs/ai-agent-integration.md) for MCP setup, key tools, and troubleshooting.
 
-1. Call `index_project` to rebuild the index
-2. Wait for indexing to complete
-3. Retry the previously failed operation
+---
 
-This pattern ensures that queries always run against an up-to-date index.
+## Why Reflex vs. built-in search tools
 
-**Available MCP Tools:**
-1. **`list_locations`** - Fast location discovery (file + line only, minimal tokens)
-2. **`count_occurrences`** - Quick statistics (total count + file count)
-3. **`search_code`** - Full-text or symbol search with detailed results
-4. **`search_regex`** - Regex pattern matching
-5. **`search_ast`** - AST pattern matching (structure-aware, slow)
-6. **`index_project`** - Trigger reindexing
-7. **`get_dependencies`** - Get all dependencies of a specific file
-8. **`get_dependents`** - Get all files that depend on a file (reverse lookup)
-9. **`get_transitive_deps`** - Get transitive dependencies up to a specified depth
-10. **`find_hotspots`** - Find most-imported files (with pagination)
-11. **`find_circular`** - Detect circular dependencies (with pagination)
-12. **`find_unused`** - Find files with no incoming dependencies (with pagination)
-13. **`find_islands`** - Find disconnected components (with pagination)
-14. **`analyze_summary`** - Get dependency analysis summary (counts only)
+| Capability | grep / ripgrep | Built-in AI search | Sourcegraph | **Reflex** |
+|---|---|---|---|---|
+| Full-text search | ✅ | ✅ | ✅ | ✅ |
+| Symbol-aware filtering | ❌ | Partial | ✅ | ✅ |
+| Dependency analysis | ❌ | ❌ | Partial | ✅ |
+| Deterministic results | ✅ | ❌ | ✅ | ✅ |
+| Local-first / offline | ✅ | ❌ | ❌ | ✅ |
+| MCP server built-in | ❌ | — | ❌ | ✅ |
+| JSON output for agents | Manual | ✅ | ✅ | ✅ |
 
-### `rfx analyze`
+---
 
-Analyze codebase structure and dependencies. By default shows a summary; use specific flags for detailed results.
+## MCP tools
 
-**Subcommands:**
-- `--circular` - Detect circular dependencies (A → B → C → A)
-- `--hotspots` - Find most-imported files
-- `--unused` - Find files with no incoming dependencies
-- `--islands` - Find disconnected components
+When connected via MCP, your AI assistant gets these tools:
 
-**Pagination (default: 200 results per page):**
-- Use `--limit N` to specify results per page
-- Use `--offset N` to skip first N results
-- Use `--all` to return unlimited results
+| Tool | What it does |
+|---|---|
+| `search_code` | Full-text or symbol search with line numbers and context |
+| `list_locations` | Fast file+line discovery (minimal tokens) |
+| `count_occurrences` | Quick match statistics without full content |
+| `search_regex` | Regex pattern matching across the codebase |
+| `search_ast` | Structure-aware search via Tree-sitter AST queries |
+| `index_project` | Trigger or refresh the search index |
+| `get_dependencies` | All imports for a specific file |
+| `get_dependents` | All files that import a given file (reverse lookup) |
+| `get_transitive_deps` | Transitive dependency graph up to a configurable depth |
+| `find_hotspots` | Most-imported files (dependency hotspots) |
+| `find_circular` | Detect circular dependency chains |
+| `find_unused` | Files with no incoming dependencies |
+| `find_islands` | Disconnected components in the dependency graph |
+| `analyze_summary` | High-level dependency counts and metrics |
+| `gather_context` | Codebase structure and project-type summary |
 
-**Examples:**
-```bash
-# Show summary of all analyses
-rfx analyze
+**Index not found error?** If an MCP tool returns `"Index not found. Run 'rfx index' to build the cache first"`, call `index_project` first, then retry the failed tool.
 
-# Find circular dependencies
-rfx analyze --circular
+---
 
-# Find hotspots (most-imported files)
-rfx analyze --hotspots --min-dependents 5
+## CLI usage
 
-# Find unused files
-rfx analyze --unused
-
-# Find disconnected components (islands)
-rfx analyze --islands --min-island-size 3
-
-# Get JSON summary of all analyses
-rfx analyze --json
-
-# Get pretty-printed JSON summary
-rfx analyze --json --pretty
-
-# Paginate results
-rfx analyze --hotspots --limit 50 --offset 0  # First 50
-rfx analyze --hotspots --limit 50 --offset 50 # Next 50
-
-# Export as JSON with pagination metadata
-rfx analyze --circular --json
-```
-
-**JSON Output Format (specific analyses with pagination):**
-```json
-{
-  "pagination": {
-    "total": 347,
-    "count": 200,
-    "offset": 0,
-    "limit": 200,
-    "has_more": true
-  },
-  "results": [...]
-}
-```
-
-**Summary JSON Output Format (bare `rfx analyze --json`):**
-```json
-{
-  "circular_dependencies": 17,
-  "hotspots": 10,
-  "unused_files": 82,
-  "islands": 81,
-  "min_dependents": 2
-}
-```
-
-### `rfx deps`
-
-Analyze dependencies for a specific file. Shows what a file imports (dependencies) or what imports it (dependents).
-
-**Key Options:**
-- `--reverse` - Show files that depend on this file (reverse lookup)
-- `--depth N` - Traverse N levels deep for transitive dependencies (default: 1)
-- `--format` - Output format: tree, table, json (default: tree)
-- `--json` - Output as JSON
-- `--pretty` - Pretty-print JSON output
-
-**Examples:**
-```bash
-# Show direct dependencies
-rfx deps src/main.rs
-
-# Show files that import this file (reverse lookup)
-rfx deps src/config.rs --reverse
-
-# Show transitive dependencies (depth 3)
-rfx deps src/api.rs --depth 3
-
-# JSON output
-rfx deps src/main.rs --json
-
-# Pretty-printed JSON
-rfx deps src/main.rs --json --pretty
-
-# Table format
-rfx deps src/main.rs --format table
-```
-
-**Supported Languages:** Rust, TypeScript, JavaScript, Python, Go, Java, C, C++, C#, PHP, Ruby, Kotlin
-
-**Note:** Only static imports (string literals) are tracked. Dynamic imports are filtered by design.
-
-### `rfx context`
-
-Generate codebase context for AI prompts. Useful with `rfx ask --additional-context`.
-
-**Key Options:**
-- `--structure` - Show directory structure
-- `--file-types` - Show file type distribution
-- `--project-type` - Detect project type (CLI/library/webapp/monorepo)
-- `--framework` - Detect frameworks and conventions
-- `--entry-points` - Show entry point files
-- `--test-layout` - Show test organization pattern
-- `--config-files` - List important configuration files
-- `--path <PATH>` - Focus on specific directory
-- `--depth <N>` - Tree depth for structure (default: 1)
-
-By default (no flags), all context types are shown. Use individual flags to show specific types only.
-
-**Examples:**
-```bash
-# Full context (all types - default behavior)
-rfx context
-
-# Full context for monorepo subdirectory
-rfx context --path services/backend
-
-# Specific context types only
-rfx context --framework --entry-points
-
-# Use with semantic queries
-rfx ask "find auth code" --additional-context "$(rfx context --framework)"
-```
-
-### `rfx llm`
-
-Manage LLM provider configuration. This is the central place to set up API keys and model preferences used by both `rfx ask` and `rfx pulse`.
+Reflex also works as a standalone CLI for humans and shell scripts.
 
 ```bash
-rfx llm config                    # Launch interactive setup wizard
-rfx llm status                    # Show current provider, model, and API key status
+# Full-text search (finds every occurrence)
+rfx query "extract_symbols"
+
+# Symbol definitions only (faster, uses tree-sitter)
+rfx query "extract_symbols" --symbols
+
+# Filter by language and symbol kind
+rfx query "parse" --lang rust --kind function --symbols
+
+# Regex search
+rfx query "fn.*test" --regex
+
+# JSON output for programmatic use
+rfx query "unwrap" --json --limit 10
+
+# Pipe file paths to other tools
+vim $(rfx query "TODO" --paths)
 ```
 
-**Example output of `rfx llm status`:**
-```
-Provider: openrouter
-Model:    meta-llama/llama-4-maverick
-API key:  configured (sk-or-...****)
-```
+**Interactive TUI mode** — run `rfx query` with no pattern to launch live search with keyboard navigation.
 
-Configuration is stored in `~/.reflex/config.toml` and applies to all LLM-powered features.
-
-### `rfx pulse`
-
-Generate codebase intelligence surfaces from structural index data. Pulse turns the facts Reflex already extracts (symbols, dependencies, hotspots, file metrics) into browsable documentation.
-
-**Surfaces:**
-- **Digest** - A periodic change report comparing two snapshots, showing file changes, dependency shifts, hotspot movements, and threshold alerts
-- **Wiki** - Per-module documentation pages with structure breakdowns, dependency lists, metrics, and optional LLM-generated summaries
-- **Map** - An architecture diagram exported as Mermaid or D2
-- **Site** - A complete static HTML site combining all three surfaces
-
-**LLM narration** is optional. When an API key is configured (via `rfx llm config`), Pulse uses your LLM provider to generate concise narrative summaries for each section. Without an API key, all output is structural-only. Use `--no-llm` to explicitly skip narration even when a key is available.
-
-LLM responses are cached in `.reflex/pulse/llm-cache/` keyed by structural content hash, so repeated runs with the same data skip the LLM entirely.
-
-**Prerequisites:** Run `rfx index` and `rfx snapshot` before using Pulse. Digests compare two snapshots, so you need at least one snapshot (two for a diff).
+### Dependency analysis
 
 ```bash
-# Generate a structural-only digest (no LLM required)
-rfx pulse digest --no-llm
-
-# Generate a digest with LLM narration (requires configured API key)
-rfx pulse digest
-
-# Compare specific snapshots
-rfx pulse digest --baseline <ID> --current <ID>
-
-# Output as JSON
-rfx pulse digest --json --pretty
+rfx deps src/main.rs              # Show direct imports
+rfx deps src/config.rs --reverse  # What imports this file
+rfx deps src/api.rs --depth 3     # Transitive dependencies
+rfx analyze --circular            # Find circular dependency chains
+rfx analyze --hotspots            # Most-imported files
+rfx analyze --unused              # Files with no incoming dependencies
 ```
+
+### Natural language search
 
 ```bash
-# Generate wiki pages for all detected modules
-rfx pulse wiki --no-llm
-
-# Generate wiki with LLM summaries
-rfx pulse wiki
-
-# Write wiki pages to a directory as markdown files
-rfx pulse wiki --output docs/wiki
-
-# Output as JSON
-rfx pulse wiki --json
+rfx ask "Find all TODOs in Rust files"         # Translate to rfx query and run
+rfx ask "How does authentication work?" --agentic  # Multi-step codebase reasoning
+rfx ask                                        # Interactive chat mode
 ```
+
+Requires an AI provider configured via `rfx llm config` (OpenAI, Anthropic, OpenRouter, or any OpenAI-compatible endpoint).
+
+### Other commands
 
 ```bash
-# Export architecture map (Mermaid format, default)
-rfx pulse map
-
-# Export as D2 format
-rfx pulse map --format d2
-
-# Focus on a specific module
-rfx pulse map --zoom src/parsers
-
-# Write to file
-rfx pulse map --output architecture.mmd
+rfx index                 # Build / update the search index
+rfx index status          # Background indexing status
+rfx watch                 # Auto-reindex on file changes
+rfx stats                 # Index statistics
+rfx pulse digest          # Codebase change digest
+rfx pulse wiki            # Per-module documentation
+rfx pulse map             # Architecture diagram (Mermaid / D2)
+rfx serve --port 7878     # Local HTTP API server
 ```
+
+Run `rfx <command> --help` for full options.
+
+---
+
+## Installation
+
+### NPM (recommended)
 
 ```bash
-# Generate a complete static HTML site with all surfaces
-rfx pulse generate --output pulse-site
-
-# Structural-only site (no LLM)
-rfx pulse generate --no-llm
-
-# Select specific surfaces
-rfx pulse generate --include wiki,digest
-
-# Clean output directory before generating
-rfx pulse generate --clean
-
-# Custom title and base URL
-rfx pulse generate --title "My Project" --base-url /docs/
+npm install -g reflex-search
 ```
 
-### Other Commands
+### Cargo
 
-- `rfx stats` - Display index statistics
-- `rfx clear` - Clear the search index
-- `rfx list-files` - List all indexed files
-- `rfx watch` - Watch for file changes and auto-reindex
-
-Run `rfx <command> --help` for detailed options.
-
-## 🌳 AST Pattern Matching
-
-Reflex supports **structure-aware code search** using Tree-sitter AST queries.
-
-**⚠️ WARNING:** AST queries are **SLOW** and scan the entire codebase. **Use `--symbols` instead for 95% of cases** (much faster).
-
-**When to use AST queries:**
-- You need to match code structure, not just text
-- `--symbols` search is insufficient for your use case
-- You have a very specific structural pattern
-
-**Basic usage:**
 ```bash
-rfx query <PATTERN> --ast <AST_PATTERN> --lang <LANGUAGE>
-
-# Example: Find all Rust functions
-rfx query "fn" --ast "(function_item) @fn" --lang rust
-
-# Example: Find all TypeScript classes
-rfx query "class" --ast "(class_declaration) @class" --lang typescript
+cargo install reflex-search
 ```
 
-**Supported languages:** Rust, TypeScript, JavaScript, Python, Go, Java, C, C++, C#, PHP, Ruby, Kotlin, Zig
+**Setup note:** run `rfx` commands from your project root directory. Add `.reflex/` to your `.gitignore` to exclude the search index from version control.
 
-For detailed AST query syntax and examples, see the [Tree-sitter documentation](https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries).
+---
 
-## 🌐 Supported Languages/Dialects
+## Supported languages
 
-| Language | Extensions | Symbol Extraction |
-|----------|------------|-------------------|
-| **Rust** | `.rs` | Functions, structs, enums, traits, impls, modules, methods |
-| **TypeScript** | `.ts`, `.tsx`, `.mts`, `.cts` | Functions, classes, interfaces, types, enums, React components |
-| **JavaScript** | `.js`, `.jsx`, `.mjs`, `.cjs` | Functions, classes, constants, methods, React components |
-| **Vue** | `.vue` | Functions, constants, methods from `<script>` blocks |
-| **Svelte** | `.svelte` | Functions, variables, reactive declarations |
-| **PHP** | `.php` | Functions, classes, interfaces, traits, methods, namespaces, enums |
-| **Python** | `.py` | Functions, classes, methods, decorators, lambdas |
-| **Go** | `.go` | Functions, types, interfaces, methods, constants |
-| **Java** | `.java` | Classes, interfaces, enums, methods, fields, constructors |
-| **C** | `.c`, `.h` | Functions, structs, enums, unions, typedefs |
-| **C++** | `.cpp`, `.hpp`, `.cxx` | Functions, classes, namespaces, templates, methods |
-| **C#** | `.cs` | Classes, interfaces, structs, enums, methods, properties |
-| **Ruby** | `.rb`, `.rake`, `.gemspec` | Classes, modules, methods, constants, variables |
-| **Kotlin** | `.kt`, `.kts` | Classes, functions, interfaces, objects, properties |
-| **Zig** | `.zig` | Functions, structs, enums, constants, variables |
+Full symbol extraction (functions, classes, methods, types, etc.) for 15 languages:
 
-**Note:** Full-text search works on **all file types** regardless of parser support. Symbol filtering requires a language parser.
+**Systems:** Rust, C, C++, Zig  
+**Backend:** Python, Go, Java, C#, PHP, Ruby, Kotlin  
+**Frontend:** TypeScript, JavaScript, Vue, Svelte
 
-## 🏗️ Architecture
+Full-text search works on **all file types** regardless of parser support.
 
-Reflex uses a **trigram-based inverted index** combined with **runtime symbol detection**:
+---
 
-### Indexing Phase
-1. Extract trigrams (3-character substrings) from all files
-2. Build inverted index: `trigram → [file_id, line_no]`
-3. Store full file contents in memory-mapped `content.bin`
-4. Start background symbol indexing (caches symbols for faster queries)
-
-### Query Phase
-1. **Full-text queries**: Intersect trigram posting lists → verify matches
-2. **Symbol queries**: Trigrams narrow to ~10-100 candidates → parse with tree-sitter → filter symbols
-3. Memory-mapped I/O for instant cache access
-
-### Cache Structure (`.reflex/`)
-```
-.reflex/
-  meta.db          # SQLite: file metadata, stats, config, hashes
-  trigrams.bin     # Inverted index (memory-mapped)
-  content.bin      # Full file contents (memory-mapped)
-  config.toml      # Index settings
-  indexing.status  # Background symbol indexer status
-```
-
-## ⚡ Performance
-
-Reflex is designed for speed at every level:
-
-**Query Performance:**
-- **Full-text & Regex**: Efficient queries via trigram indexing
-- **Symbol queries**: Slower due to runtime tree-sitter parsing, but still efficient
-- **Cached queries**: Repeated searches benefit from memory-mapped cache
-- Scales well from small projects to large codebases (10k+ files)
-
-**Indexing Performance:**
-- **Initial indexing**: Parallel processing using 80% of CPU cores
-- **Incremental updates**: Only reindexes changed files via blake3 hashing
-- **Memory-mapped I/O**: Zero-copy access for cache reads
-
-## 🔧 Configuration
-
-Reflex respects `.gitignore` files automatically. Additional configuration via `.reflex/config.toml`:
+## Configuration
 
 ```toml
+# .reflex/config.toml (project-level)
 [index]
-languages = []  # Empty = all supported languages
+languages = []          # Empty = all supported languages
 max_file_size = 10485760  # 10 MB
-follow_symlinks = false
 
 [search]
 default_limit = 100
 
 [performance]
-parallel_threads = 0  # 0 = auto (80% of available cores)
+parallel_threads = 0    # 0 = auto (80% of available cores)
 ```
 
-## 🤖 AI Integration
-
-Reflex provides clean JSON output for AI coding assistants and automation:
-
-```bash
-rfx query "parse_tree" --json --symbols
-```
-
-Output includes file paths, line numbers, symbol types, and code previews with pagination metadata.
-
-## 🔍 Use Cases
-
-- **Code Navigation**: Find all usages of functions, classes, and variables
-- **Refactoring**: Identify all call sites before making changes
-- **AI Assistants**: Retrieve relevant code snippets and context for LLMs
-- **Debugging**: Locate where variables and functions are used
-- **Documentation**: Find examples of API usage across the codebase
-- **Security**: Search for potential vulnerabilities or anti-patterns
-
-## 🧪 Testing
-
-Reflex has comprehensive test coverage including core modules, real-world code samples across all supported languages, and end-to-end workflows.
-
-```bash
-cargo test                    # Run all tests
-cargo test -- --nocapture     # Run with output
-cargo test indexer::tests     # Run specific module
-```
-
-## 🔒 Security / Threat Model
-
-### `rfx serve` HTTP API
-
-`rfx serve` starts a local HTTP API server. It is designed as a **local-only, single-user tool** with no authentication.
-
-| Setting | Default | Notes |
-|---------|---------|-------|
-| Bind address | `127.0.0.1` (loopback) | Accessible only from the local machine |
-| Port | `7878` | Configurable with `--port` |
-| Authentication | None | By design — local tool only |
-
-**To bind to a different address:**
-```bash
-rfx serve --host 0.0.0.0 --port 7878   # ⚠️ Exposes to the network
-```
-
-> **Warning:** Binding to `0.0.0.0` or any non-loopback address exposes your entire codebase index to the network without authentication. Do not do this on shared or internet-facing machines. If you need network-accessible search, place an authenticated reverse proxy in front of it.
-
-### JSON Output: Language Field
-
-The `language` field in search results serializes as an enum string (e.g. `"Rust"`, `"Python"`). For unrecognized file types it serializes as `"Unknown"`. **Do not exhaustively match on this field** — new languages may be added in minor releases. Always include an `"Unknown"` fallback in your client code.
-
-## 🤝 Contributing
-
-Contributions welcome! Reflex is built to be:
-- **Fast**: Efficient search using trigram indexing and memory-mapped I/O
-- **Accurate**: Complete coverage with deterministic results
-- **Extensible**: Easy to add new language parsers
-
-## 📄 License
-
-MIT License - see [LICENSE](LICENSE) for details.
-
-## 🙏 Acknowledgments
-
-Built with:
-- [tree-sitter](https://tree-sitter.github.io/tree-sitter/) - Incremental parsing
-- [rkyv](https://rkyv.org/) - Zero-copy deserialization
-- [memmap2](https://github.com/RazrFalcon/memmap2-rs) - Memory-mapped I/O
-- [rusqlite](https://github.com/rusqlite/rusqlite) - SQLite bindings
-- [blake3](https://github.com/BLAKE3-team/BLAKE3) - Fast hashing
-- [ignore](https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore) - gitignore support
-
-Inspired by:
-- [Zoekt](https://github.com/sourcegraph/zoekt) - Trigram-based code search
-- [Sourcegraph](https://sourcegraph.com/) - Code search for teams
-- [ripgrep](https://github.com/BurntSushi/ripgrep) - Fast text search
+For AI provider configuration (`rfx ask`, `rfx pulse`), run `rfx llm config`.
 
 ---
 
-**Made with ❤️ for developers and AI coding assistants**
+## Architecture
+
+Reflex uses a **trigram-based inverted index** with **runtime symbol detection**:
+
+- **Indexing**: extracts 3-character trigrams from all files; stores full content in memory-mapped `content.bin`; no tree-sitter parsing at index time
+- **Full-text queries**: intersect trigram posting lists → verify matches (instant)
+- **Symbol queries**: trigrams narrow candidates → parse only matching files with tree-sitter
+
+```
+.reflex/
+  meta.db          # SQLite: file metadata, stats, config
+  trigrams.bin     # Inverted index (memory-mapped)
+  content.bin      # Full file contents (memory-mapped)
+  config.toml      # Index settings
+```
+
+---
+
+## Security
+
+`rfx serve` binds to `127.0.0.1:7878` by default — loopback only, no authentication. Do not expose it to the network. See [CLAUDE.md](CLAUDE.md#security--threat-model) for the full threat model.
+
+---
+
+## Contributing
+
+```bash
+cargo build --release   # Build
+cargo test              # Test
+rfx index               # Refresh index after code changes
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE) for details.
+
+---
+
+**Fast code search for developers — works standalone, in scripts, and with AI coding agents**

--- a/docs/ai-agent-integration.md
+++ b/docs/ai-agent-integration.md
@@ -177,3 +177,13 @@ Found 42 results in 5ms:
 ```
 
 This is useful for human operators but not recommended for AI agents.
+
+## MCP Tool Selection
+
+When using Reflex via MCP (Model Context Protocol), use the **[MCP Tool Selection Cheatsheet](./mcp-tool-cheatsheet.md)** to pick the right tool for each task. It organizes all 15 tools into a decision tree by agent intent:
+
+- **Finding locations** → `list_locations`, `count_occurrences`
+- **Finding definitions** → `search_code(symbols: true)`
+- **Understanding a file** → `get_dependencies`, `get_dependents`, `get_transitive_deps`
+- **Codebase overview** → `gather_context`, `analyze_summary`, `find_hotspots`
+- **Complex patterns** → `search_regex`, `search_ast` (last resort)

--- a/docs/ai-agent-integration.md
+++ b/docs/ai-agent-integration.md
@@ -1,25 +1,293 @@
-# AI Agent Integration Guide
+# Claude Code + Reflex MCP Quickstart
 
-Reflex is designed to be AI-agent-friendly with JSON output that includes index metadata. This allows agents to:
+Get Reflex working as an MCP tool server inside Claude Code in under 5 minutes.
 
-1. **Detect stale indices** automatically
-2. **Re-index when needed** without user intervention
-3. **Trust the results** knowing they're up-to-date
+---
 
-## JSON Output Format
+## Prerequisites
 
-When using the `--json` flag, Reflex returns a structured response with metadata:
+- [Claude Code](https://claude.ai/code) installed and working
+- A project directory you want to search
+
+---
+
+## Step 1 — Install Reflex
+
+**Via npm (recommended):**
+
+```bash
+npm install -g reflex-search
+```
+
+**Via cargo:**
+
+```bash
+cargo install reflex-search
+```
+
+Verify the install:
+
+```bash
+rfx --version
+```
+
+> **Cargo users:** If `rfx` is not found after install, add `~/.cargo/bin` to your `PATH`:
+> ```bash
+> export PATH="$HOME/.cargo/bin:$PATH"
+> ```
+
+---
+
+## Step 2 — Add Reflex to Claude Code
+
+Open your Claude Code MCP settings file. The right scope depends on your use case:
+
+| Scope | File |
+|-------|------|
+| All projects (global) | `~/.claude/claude_code_config.json` |
+| This project only | `.claude/claude_code_config.json` |
+
+Add the `reflex` entry under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "reflex": {
+      "command": "rfx",
+      "args": ["mcp"],
+      "env": {},
+      "disabled": false
+    }
+  }
+}
+```
+
+> **Note:** `rfx mcp` runs as a stdio MCP server. Claude Code starts and manages it
+> automatically — you should not run this command manually in your terminal.
+
+After saving, restart Claude Code (or use **Reload Window** in VS Code) to pick up the
+new server.
+
+---
+
+## Step 3 — Index your project
+
+Navigate to your project root and build the search index:
+
+```bash
+cd /path/to/your/project
+rfx index
+```
+
+Indexing is incremental: subsequent runs only process changed files. The first index on a
+typical project (10–50k files) takes a few seconds.
+
+> **Tip:** Add `.reflex/` to your `.gitignore` to keep the cache local.
+> ```
+> echo ".reflex/" >> .gitignore
+> ```
+
+---
+
+## Step 4 — Your first search
+
+In a Claude Code conversation, ask a question that requires code search. Claude invokes
+Reflex automatically via MCP:
+
+> *"Where is the `parse_config` function defined in this project?"*
+
+Behind the scenes, Claude calls the `search_code` tool:
+
+```json
+{
+  "tool": "search_code",
+  "arguments": {
+    "pattern": "parse_config",
+    "symbols": true
+  }
+}
+```
+
+The response includes exact file paths, line numbers, and code previews — no shell
+scripting or manual `grep` required.
+
+---
+
+## Key Tools for AI Agents
+
+The five tools Claude uses most often in a Reflex-indexed codebase:
+
+### `search_code` — find anything
+
+Full-text or symbol-only search with line numbers and code previews.
+
+```json
+// All usages of a function
+{ "pattern": "process_request" }
+
+// Definitions only (not usages)
+{ "pattern": "process_request", "symbols": true }
+
+// Filter to a specific language
+{ "pattern": "process_request", "lang": "rust", "symbols": true }
+
+// Scope to a subdirectory
+{ "pattern": "process_request", "glob": ["src/api/**/*.rs"] }
+```
+
+### `list_locations` — where, without the noise
+
+Returns `[{path, line}]` only — no code previews. Use this to quickly enumerate all
+locations before deciding which files to read.
+
+```json
+{ "pattern": "TODO" }
+// → [{"path": "src/auth.rs", "line": 42}, {"path": "src/cache.rs", "line": 7}, ...]
+```
+
+### `gather_context` — orient to a new project
+
+Returns directory structure, detected frameworks, entry points, and file-type
+distribution. Run this at the start of a session when you are unfamiliar with a codebase.
+
+```json
+{ "structure": true, "framework": true, "entry_points": true }
+```
+
+### `get_dependencies` — what does this file import?
+
+Returns all static imports for a file with their classification
+(internal / external / stdlib).
+
+```json
+{ "path": "src/auth/middleware.rs" }
+```
+
+### `index_project` — keep the index fresh
+
+Trigger a reindex after code changes (git pull, file creation, refactor).
+
+```json
+{}
+
+// Force a full rebuild if results seem wrong:
+{ "force": true }
+```
+
+> **Planned:** `find_references` for cross-file symbol usage tracking is coming in a
+> future release.
+
+---
+
+## Tips
+
+### Re-indexing after code changes
+
+Reflex does not watch for changes by default. Re-index manually after significant edits:
+
+```bash
+rfx index          # Fast incremental update (changed files only)
+rfx index --force  # Full rebuild from scratch
+```
+
+Or run the watcher to keep the index live during active development:
+
+```bash
+rfx watch
+```
+
+### Glob filters in monorepos
+
+Scope searches to a specific package or service to reduce noise:
+
+```json
+{
+  "pattern": "useAuth",
+  "glob": ["packages/web/**/*.ts"]
+}
+```
+
+### Excluding noisy directories
+
+```json
+{
+  "pattern": "TODO",
+  "exclude": ["**/node_modules/**", "**/vendor/**", "**/target/**"]
+}
+```
+
+### Index staleness detection
+
+When Claude gets results that look stale, it can call `index_project` to refresh and then
+retry — all within the same conversation. You do not need to leave the chat.
+
+---
+
+## Troubleshooting
+
+### "Index not found" error
+
+The `.reflex/` cache has not been built yet for this directory. Run `rfx index` from the
+**project root** — the same directory you opened in Claude Code.
+
+```bash
+rfx index
+```
+
+### Missing new files or stale results
+
+After pulling changes or creating files, the index may lag behind. Re-index:
+
+```bash
+rfx index
+```
+
+If errors persist after an incremental index, force a full rebuild:
+
+```bash
+rfx index --force
+```
+
+### MCP server not connecting
+
+1. Confirm `rfx` is on your `PATH`:
+   ```bash
+   which rfx
+   ```
+2. Check the settings JSON for syntax errors — trailing commas and unquoted keys break
+   JSON parsing.
+3. Restart Claude Code after editing the config file.
+4. Check Claude Code's MCP server logs for error output from `rfx mcp`.
+
+### MCP server exits unexpectedly
+
+`rfx mcp` runs as a long-lived process over stdio. If it exits unexpectedly, Claude Code
+will surface an error in the tool result. Run `rfx mcp` manually in a terminal to see any
+startup errors, then report a bug with the output.
+
+---
+
+## Legacy: CLI / JSON Mode
+
+If you are integrating Reflex into a shell script or non-MCP agent, you can use the
+`--json` flag directly on the CLI:
+
+```bash
+rfx query "pattern" --json
+```
+
+### JSON Output Format
+
+The `--json` response includes a `metadata` block for staleness detection:
 
 ```json
 {
   "metadata": {
-    "status": "fresh" | "branch_not_indexed" | "commit_changed" | "files_modified",
-    "reason": "Human-readable explanation (if stale)",
+    "status": "fresh",
     "current_branch": "main",
     "indexed_branch": "main",
     "current_commit": "74eb454...",
-    "indexed_commit": "74eb454...",
-    "action_required": "rfx index"
+    "indexed_commit": "74eb454..."
   },
   "results": [
     {
@@ -27,41 +295,26 @@ When using the `--json` flag, Reflex returns a structured response with metadata
       "lang": "rust",
       "kind": "Struct",
       "symbol": "CacheManager",
-      "span": {
-        "start_line": 42,
-        "start_col": 0,
-        "end_line": 45,
-        "end_col": 1
-      },
-      "scope": null,
+      "span": { "start_line": 42, "start_col": 0, "end_line": 45, "end_col": 1 },
       "preview": "pub struct CacheManager {"
     }
   ]
 }
 ```
 
-## Metadata Fields
+**`metadata.status` values:**
 
-### `status` (required)
-- `"fresh"`: Index is up-to-date
-- `"branch_not_indexed"`: Current git branch has not been indexed
-- `"commit_changed"`: HEAD has moved since last index
-- `"files_modified"`: Files have been modified (detected via sampling)
+| Value | Meaning |
+|-------|---------|
+| `fresh` | Index is up to date |
+| `branch_not_indexed` | Current git branch has not been indexed |
+| `commit_changed` | HEAD has moved since last index |
+| `files_modified` | Files modified since last index (detected via sampling) |
 
-### `reason` (optional)
-Human-readable explanation of why the index is stale (omitted if fresh).
+When `status !== "fresh"`, the response also includes `reason` (human-readable
+explanation) and `action_required` (command to fix, typically `"rfx index"`).
 
-### `action_required` (optional)
-Command to run to fix staleness (typically `"rfx index"`). Omitted if fresh.
-
-### Git fields (optional)
-Only present if in a git repository:
-- `current_branch`: The branch you're currently on
-- `indexed_branch`: The branch that was indexed
-- `current_commit`: Current HEAD commit SHA
-- `indexed_commit`: Commit SHA when index was created
-
-## Example: Bash Script
+### Bash example
 
 ```bash
 #!/bin/bash
@@ -69,121 +322,35 @@ response=$(rfx query "pattern" --json)
 status=$(echo "$response" | jq -r '.metadata.status')
 
 if [ "$status" != "fresh" ]; then
-    echo "⚠️  Index is stale, re-indexing..." >&2
+    echo "Index stale, re-indexing..." >&2
     rfx index
     response=$(rfx query "pattern" --json)
 fi
 
-# Use results
 echo "$response" | jq '.results'
 ```
 
-## Example: Python
+### Python example
 
 ```python
-import subprocess
-import json
+import subprocess, json
 
 def query_with_auto_reindex(pattern: str):
-    """Query Reflex, automatically re-index if stale."""
     response = json.loads(
         subprocess.check_output(["rfx", "query", pattern, "--json"])
     )
-
     if response["metadata"]["status"] != "fresh":
-        print(f"⚠️  Index stale: {response['metadata']['reason']}")
+        print(f"Index stale: {response['metadata']['reason']}")
         subprocess.run(["rfx", "index"], check=True)
-
-        # Re-query with fresh index
         response = json.loads(
             subprocess.check_output(["rfx", "query", pattern, "--json"])
         )
-
     return response["results"]
-
-# Usage
-results = query_with_auto_reindex("CacheManager")
-for result in results:
-    print(f"{result['path']}:{result['span']['start_line']} - {result['symbol']}")
 ```
 
-## Example: TypeScript/JavaScript
+### Exit codes
 
-```typescript
-import { exec } from 'child_process';
-import { promisify } from 'util';
-
-const execAsync = promisify(exec);
-
-async function queryWithAutoReindex(pattern: string) {
-  const { stdout } = await execAsync(`rfx query "${pattern}" --json`);
-  let response = JSON.parse(stdout);
-
-  if (response.metadata.status !== 'fresh') {
-    console.error(`⚠️  Index stale: ${response.metadata.reason}`);
-    await execAsync('rfx index');
-
-    // Re-query
-    const { stdout: newStdout } = await execAsync(`rfx query "${pattern}" --json`);
-    response = JSON.parse(newStdout);
-  }
-
-  return response.results;
-}
-
-// Usage
-const results = await queryWithAutoReindex('CacheManager');
-results.forEach(r => {
-  console.log(`${r.path}:${r.span.start_line} - ${r.symbol}`);
-});
-```
-
-## Best Practices for AI Agents
-
-1. **Always use `--json` for programmatic access**: This ensures you get structured metadata.
-
-2. **Check `metadata.status` before trusting results**: Don't assume the index is fresh.
-
-3. **Auto-reindex on stale**: If `status !== "fresh"`, run the `action_required` command.
-
-4. **Handle errors gracefully**: Index might not exist at all (first run).
-
-5. **Cache awareness**: Indexing is fast (~200ms for most projects), so re-indexing on demand is acceptable.
-
-6. **Branch switching**: If you switch git branches, expect `status: "branch_not_indexed"` until you index the new branch.
-
-## Performance Notes
-
-- **Index freshness check**: <5ms overhead (lightweight git operations)
-- **File sampling**: Checks up to 10 files for modifications (cheap mtime + hash)
-- **Re-indexing**: ~200ms for typical projects (incremental, only changed files)
-
-## Exit Codes
-
-Reflex uses standard exit codes:
-- `0`: Success (results found and index fresh)
-- `1`: No results found or error
-- (Future) `2`: Results found but index stale
-
-## Non-JSON Fallback
-
-Without `--json`, Reflex prints warnings to stderr:
-
-```bash
-$ rfx query "pattern"
-⚠️  WARNING: Index may be stale (commit changed: abc1234 → def5678). Consider running 'rfx index'.
-Found 42 results in 5ms:
-...
-```
-
-This is useful for human operators but not recommended for AI agents.
-
-## MCP Tool Selection
-
-When using Reflex via MCP (Model Context Protocol), use the **[MCP Tool Selection Cheatsheet](./mcp-tool-cheatsheet.md)** to pick the right tool for each task. It organizes all 15 tools into a decision tree by agent intent:
-
-- **Finding locations** → `list_locations`, `count_occurrences`
-- **Finding definitions** → `search_code(symbols: true)`
-- **Understanding a file** → `get_dependencies`, `get_dependents`, `get_transitive_deps`
-- **Codebase overview** → `gather_context`, `analyze_summary`, `find_hotspots`
-- **Complex patterns** → `search_regex`, `search_ast` (last resort)
+| Code | Meaning |
+|------|---------|
+| `0` | Success (results found, index fresh) |
+| `1` | No results found or error |

--- a/docs/mcp-tool-cheatsheet.md
+++ b/docs/mcp-tool-cheatsheet.md
@@ -1,0 +1,203 @@
+# Reflex MCP Tool Selection Cheatsheet
+
+> **Quick rule:** Start cheap, escalate only when needed.
+> `list_locations` → `search_code` → `search_regex` → `search_ast` (last resort)
+
+---
+
+## Decision Tree by Agent Intent
+
+### "I want to find WHERE something is"
+
+| Goal | Tool | Why |
+|------|------|-----|
+| Known exact name, just need locations | `list_locations` | Cheapest — returns `{path, line}` only, no content |
+| Need locations **and** code previews | `search_code` | Full results with line numbers + context |
+| Pattern has special chars (`->`, `::`, `()`, regex) | `search_regex` | Required for non-alphanumeric patterns |
+| How many times does X appear? | `count_occurrences` | Returns `{total, files}` — no content loaded |
+
+```
+"Where is UserController used?"
+  → list_locations(pattern: "UserController")
+
+"How many places call unwrap()?"
+  → count_occurrences(pattern: "unwrap()")   # has special chars? no → search_code first
+  → count_occurrences + search_regex(pattern: "unwrap\\(")
+```
+
+---
+
+### "I want to find WHAT something is (definition)"
+
+| Goal | Tool | Why |
+|------|------|-----|
+| Symbol definition (function/class/struct) | `search_code(symbols: true)` | Filters to definitions only |
+| Symbol definition **with full body** | `search_code(symbols: true, expand: true)` | Shows complete implementation |
+| Structural match (e.g., "async fn with error handling") | `search_ast` | ⚠️ SLOW — use only when text search fails |
+
+```
+"Find the definition of extract_symbols"
+  → search_code(pattern: "extract_symbols", symbols: true)
+
+"Show me the full body of build_index"
+  → search_code(pattern: "build_index", symbols: true, expand: true)
+```
+
+---
+
+### "I want to understand a FILE"
+
+| Goal | Tool | Why |
+|------|------|-----|
+| What does this file import? | `get_dependencies` | Returns all static imports with type (internal/external/stdlib) |
+| What files import this file? | `get_dependents` | Reverse lookup — impact of changes |
+| Full import tree (deps of deps) | `get_transitive_deps` | Traverses N levels deep (default: 3) |
+
+```
+"What does src/query.rs depend on?"
+  → get_dependencies(path: "src/query.rs")
+
+"What breaks if I change models/User.php?"
+  → get_dependents(path: "User.php")
+
+"Show the full dependency chain for main.rs"
+  → get_transitive_deps(path: "src/main.rs", depth: 3)
+```
+
+> **Note:** All dependency tools extract **static imports only**. Dynamic imports (variables, template literals) are filtered by design.
+
+---
+
+### "I want to understand the CODEBASE"
+
+| Goal | Tool | Why |
+|------|------|-----|
+| Project type, entry points, frameworks | `gather_context` (no params) | One-shot codebase overview |
+| Dependency health at a glance | `analyze_summary` | Returns counts: circular, hotspots, unused, islands |
+| Most-imported (critical) files | `find_hotspots` | Files ranked by import count — the load-bearing modules |
+| Unused / orphaned files | `find_unused` | Candidates for deletion (verify entry points aren't included) |
+| Circular dependency cycles | `find_circular` | Returns cycle arrays: A→B→C→A |
+| Isolated subsystems | `find_islands` | Groups of files with no cross-group imports |
+
+```
+"What kind of project is this?"
+  → gather_context()
+
+"Is the dependency graph healthy?"
+  → analyze_summary()
+  → then drill into find_circular / find_hotspots / find_unused as needed
+
+"What files are most central to this codebase?"
+  → find_hotspots(min_dependents: 3)
+```
+
+---
+
+### "I need to maintain the index"
+
+| Goal | Tool | Why |
+|------|------|-----|
+| Index seems stale / missing files | `index_project` | Incremental by default; use `force: true` for full rebuild |
+| Search returns "Index not found" error | `index_project` immediately | Required before any other tool will work |
+
+```
+# Always: if any tool returns "Index not found", call this first:
+index_project()
+
+# After large git operations (checkout, merge, rebase):
+index_project()
+```
+
+---
+
+## Tool Quick Reference
+
+| Tool | Cost | Returns | Requires |
+|------|------|---------|---------|
+| `list_locations` | ⚡ Cheapest | `[{path, line}]` | `pattern` |
+| `count_occurrences` | ⚡ Cheap | `{total, files}` | `pattern` |
+| `search_code` | 🟡 Medium | Full results with previews | `pattern` |
+| `search_regex` | 🟡 Medium | Full results with previews | `pattern` |
+| `gather_context` | 🟡 Medium | Project structure summary | — |
+| `get_dependencies` | 🟡 Medium | Import list for one file | `path` |
+| `get_dependents` | 🟡 Medium | Files importing this one | `path` |
+| `get_transitive_deps` | 🟡 Medium | Dep tree up to N levels | `path` |
+| `analyze_summary` | 🟡 Medium | Counts: circular/hotspots/unused | — |
+| `find_hotspots` | 🟡 Medium | Files by import count | — |
+| `find_unused` | 🟡 Medium | Orphaned file list | — |
+| `find_circular` | 🟡 Medium | Cycle arrays | — |
+| `find_islands` | 🟡 Medium | Isolated component groups | — |
+| `index_project` | 🔴 Slow (write) | Status + stats | — |
+| `search_ast` | 🔴 Slowest | Structural matches | `pattern`, `lang` + glob |
+
+---
+
+## Tiered Workflow Example
+
+**Task:** "Understand how authentication works in this codebase"
+
+```
+# Tier 1 — Orient (cheapest)
+list_locations(pattern: "authenticate")
+# → 12 matches in 5 files
+
+# Tier 2 — Explore (targeted)
+search_code(pattern: "authenticate", symbols: true)
+# → 3 function definitions: authenticate(), auth_middleware(), verify_token()
+
+search_code(pattern: "authenticate", symbols: true, expand: true)
+# → Full bodies of all 3 definitions
+
+# Tier 3 — Context (if needed)
+get_dependencies(path: "src/auth.rs")
+# → auth.rs imports: jwt, crypto, models/user
+
+get_dependents(path: "src/auth.rs")
+# → 8 files use auth.rs — these are affected if you change it
+```
+
+---
+
+## Common Filters (available on most search tools)
+
+| Filter | Type | Example |
+|--------|------|---------|
+| `lang` | string | `"rust"`, `"typescript"`, `"python"` |
+| `glob` | array | `["src/**/*.rs"]` |
+| `exclude` | array | `["target/**", "node_modules/**"]` |
+| `file` | string | `"Controllers"` (substring match) |
+| `symbols` | bool | `true` = definitions only |
+| `kind` | string | `"function"`, `"class"`, `"struct"` |
+| `expand` | bool | `true` = show full symbol body |
+| `limit` / `offset` | int | Pagination (check `has_more` in response) |
+
+---
+
+## When to Use `search_ast` (Rare)
+
+`search_ast` is a **last resort**. Use it only when:
+1. Text search (`search_code` / `search_regex`) cannot express the pattern
+2. You need structural matching (e.g., "all async functions that contain a `match` expression")
+3. You **must** add `glob` to limit scope
+
+```
+# Acceptable (narrow glob):
+search_ast(
+  pattern: "(function_item) @fn",
+  lang: "rust",
+  glob: ["src/**/*.rs"]
+)
+
+# Never do this (no glob = full codebase scan):
+search_ast(pattern: "(function_item) @fn", lang: "rust")
+```
+
+**Performance:** `list_locations` ≈ 2ms · `search_code` ≈ 3–10ms · `search_ast` ≈ 500ms–10s+
+
+---
+
+## See Also
+
+- [AI Agent Integration Guide](./ai-agent-integration.md) — JSON output format, stale-index handling, auto-reindex patterns
+- [CLI Usage](../CLAUDE.md#cli-usage) — Human-facing `rfx` command reference
+- [Dependency Analysis](./DEPENDENCIES.md) — Deep dive into import extraction and graph analysis

--- a/docs/mcp-tool-cheatsheet.md
+++ b/docs/mcp-tool-cheatsheet.md
@@ -198,6 +198,6 @@ search_ast(pattern: "(function_item) @fn", lang: "rust")
 
 ## See Also
 
-- [AI Agent Integration Guide](./ai-agent-integration.md) — JSON output format, stale-index handling, auto-reindex patterns
+- [Claude Code + Reflex MCP Quickstart](./ai-agent-integration.md) — MCP setup, key tools, troubleshooting, and CLI/JSON fallback
 - [CLI Usage](../CLAUDE.md#cli-usage) — Human-facing `rfx` command reference
 - [Dependency Analysis](./DEPENDENCIES.md) — Deep dive into import extraction and graph analysis

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -12,8 +12,12 @@ use std::path::PathBuf;
 use crate::cache::CacheManager;
 use crate::dependency::DependencyIndex;
 use crate::indexer::Indexer;
-use crate::models::{IndexConfig, Language, SymbolKind};
+use crate::models::{IndexConfig, IndexStatus, Language, SymbolKind};
 use crate::query::{QueryEngine, QueryFilter};
+
+/// Default preview truncation length for MCP responses (characters).
+/// Raised from 100 so typical Rust/TS/Python function signatures fit without truncation.
+const DEFAULT_MCP_PREVIEW_LENGTH: usize = 180;
 
 /// JSON-RPC 2.0 request
 #[derive(Debug, Deserialize)]
@@ -258,6 +262,10 @@ fn handle_list_tools(_params: Option<Value>) -> Result<Value> {
                         "dependencies": {
                             "type": "boolean",
                             "description": "Include dependency information (imports) in results. **IMPORTANT:** Only extracts static imports (string literals). Dynamic imports (variables, template literals, expressions) are automatically filtered. See CLAUDE.md for details."
+                        },
+                        "preview_length": {
+                            "type": "integer",
+                            "description": "Maximum characters per preview line (default: 180). Use a smaller value (e.g. 60) for wide-result scans where short previews are sufficient."
                         }
                     },
                     "required": ["pattern"]
@@ -537,6 +545,50 @@ fn handle_list_tools(_params: Option<Value>) -> Result<Value> {
                 }
             },
             {
+                "name": "find_references",
+                "description": "Find a symbol's definition AND all usage sites in a single call.\n\n**Purpose:** Eliminates the two-step pattern of search_code(symbols=true) + search_code(). Returns both the definition and all usages atomically.\n\n**Returns:** {definition, references, total_references, pagination, status}\n\n**Use this when:**\n- \"Find all callers of X\" — the most common agent refactoring pattern\n- Code review: understand impact before changing a function or class\n- Rename planning: see every site that needs updating\n- Dead code detection: confirm nothing calls a function before removing it\n\n**definition:** First matching symbol definition {path, line, kind, symbol, span, preview}, or null if no symbol definition exists for the pattern.\n\n**references:** Flat array of {path, line, preview} — all textual occurrences including the definition site itself.\n\n**Pagination applies to references only.** Use limit and offset. Check pagination.has_more for more pages.\n\n**Error Handling:** If you receive an error message containing \"Index not found\" or \"stale\", immediately call the index_project tool, wait for it to complete, then retry this operation.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "pattern": {
+                            "type": "string",
+                            "description": "Symbol name or text pattern to find references for (e.g., 'CacheManager', 'extract_symbols')"
+                        },
+                        "kind": {
+                            "type": "string",
+                            "description": "Filter definition lookup by symbol kind (function, class, struct, trait, etc.)"
+                        },
+                        "lang": {
+                            "type": "string",
+                            "description": "Filter by language (rust, typescript, python, go, etc.)"
+                        },
+                        "glob": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Include files matching glob patterns (e.g., ['src/**/*.rs'])"
+                        },
+                        "exclude": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Exclude files matching glob patterns (e.g., ['target/**', 'tests/**'])"
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Max references per page (default: 100). Pagination applies to references only."
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "description": "Pagination offset for references (skip first N). Use with limit."
+                        },
+                        "force": {
+                            "type": "boolean",
+                            "description": "Force execution of potentially expensive queries (bypasses broad query detection)"
+                        }
+                    },
+                    "required": ["pattern"]
+                }
+            },
+            {
                 "name": "gather_context",
                 "description": "Collects comprehensive codebase information.\n\n**Parameters:**\n- `structure` (bool): Show directory tree\n- `file_types` (bool): Show file type distribution\n- `project_type` (bool): Detect project type (CLI/library/webapp)\n- `framework` (bool): Detect frameworks (React, Django, etc.)\n- `entry_points` (bool): Find main/index files\n- `test_layout` (bool): Show test organization\n- `config_files` (bool): List configuration files\n- `depth` (int): Tree depth for structure (default: 2)\n- `path` (string, optional): Focus on specific directory\n\n**When to use:**\n- Understanding project structure and organization\n- Finding which frameworks/languages are used\n- Locating entry points and test layouts\n- Getting file statistics and distribution\n\n**When NOT to use:**\n- Finding conceptual/architectural information (use search_documentation)\n- Understanding high-level how things work (use search_documentation)\n\n**Note:** By default (no parameters), all context types are gathered.",
                 "inputSchema": {
@@ -579,6 +631,14 @@ fn handle_list_tools(_params: Option<Value>) -> Result<Value> {
                             "description": "Focus on specific directory path"
                         }
                     }
+                }
+            },
+            {
+                "name": "check_index_status",
+                "description": "Check whether the Reflex search index is fresh, stale, or missing — without running any search.\n\n**CALL THIS FIRST** at the start of every session and before any significant search task. If the index is stale or missing, call index_project before searching.\n\n**Returns:**\n- `status`: `\"fresh\"` | `\"stale\"` | `\"missing\"`\n- `reason`: why the index is stale (branch not indexed, commit changed, files modified)\n- `action_required`: command to fix the issue (always `rfx index` when stale)\n- `files_modified`: number of recently modified files detected (only present for mtime-based staleness)\n\n**When to call:**\n- At the start of every agent session\n- Before any bulk search or refactoring task\n- After a git operation (checkout, merge, rebase, pull)\n\n**Example fresh response:** `{\"status\": \"fresh\"}`\n**Example stale response:** `{\"status\": \"stale\", \"reason\": \"Commit changed from abc1234 to def5678\", \"action_required\": \"rfx index\"}`",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {}
                 }
             }
         ]
@@ -765,6 +825,10 @@ fn handle_call_tool(params: Option<Value>) -> Result<Value> {
             let paths_only = arguments["paths"].as_bool().unwrap_or(false);
             let force = arguments["force"].as_bool().unwrap_or(false);
             let dependencies = arguments["dependencies"].as_bool().unwrap_or(false);
+            let preview_length = arguments["preview_length"]
+                .as_u64()
+                .map(|n| n as usize)
+                .unwrap_or(DEFAULT_MCP_PREVIEW_LENGTH);
 
             let language = parse_language(lang);
             let parsed_kind = parse_symbol_kind(kind);
@@ -810,11 +874,10 @@ fn handle_call_tool(params: Option<Value>) -> Result<Value> {
             let engine = QueryEngine::new(cache);
             let mut response = engine.search_with_metadata(&pattern, filter)?;
 
-            // Apply preview truncation for token efficiency (100 chars max)
-            const MAX_PREVIEW_LENGTH: usize = 100;
+            // Apply preview truncation for token efficiency
             for file_group in response.results.iter_mut() {
                 for m in file_group.matches.iter_mut() {
-                    m.preview = crate::cli::truncate_preview(&m.preview, MAX_PREVIEW_LENGTH);
+                    m.preview = crate::cli::truncate_preview(&m.preview, preview_length);
                 }
             }
 
@@ -901,11 +964,10 @@ fn handle_call_tool(params: Option<Value>) -> Result<Value> {
             let engine = QueryEngine::new(cache);
             let mut response = engine.search_with_metadata(&pattern, filter)?;
 
-            // Apply preview truncation for token efficiency (100 chars max)
-            const MAX_PREVIEW_LENGTH: usize = 100;
+            // Apply preview truncation for token efficiency
             for file_group in response.results.iter_mut() {
                 for m in file_group.matches.iter_mut() {
-                    m.preview = crate::cli::truncate_preview(&m.preview, MAX_PREVIEW_LENGTH);
+                    m.preview = crate::cli::truncate_preview(&m.preview, DEFAULT_MCP_PREVIEW_LENGTH);
                 }
             }
 
@@ -1007,10 +1069,9 @@ fn handle_call_tool(params: Option<Value>) -> Result<Value> {
             // Use the new search_ast_all_files method (no trigram filtering)
             let mut results = engine.search_ast_all_files(&ast_pattern, filter)?;
 
-            // Apply preview truncation for token efficiency (100 chars max)
-            const MAX_PREVIEW_LENGTH: usize = 100;
+            // Apply preview truncation for token efficiency
             for result in &mut results {
-                result.preview = crate::cli::truncate_preview(&result.preview, MAX_PREVIEW_LENGTH);
+                result.preview = crate::cli::truncate_preview(&result.preview, DEFAULT_MCP_PREVIEW_LENGTH);
             }
 
             Ok(json!({
@@ -1509,24 +1570,194 @@ fn handle_call_tool(params: Option<Value>) -> Result<Value> {
                 json: false,  // MCP always returns text format
             };
 
-            // If no context flags specified, enable all types (default behavior)
-            if opts.is_empty() {
-                opts.structure = true;
-                opts.file_types = true;
+            // If no context flags specified, return minimal orientation context only.
+            // Requesting all types by default floods agent context windows (2000-5000 tokens).
+            let no_flags_set = opts.is_empty();
+            if no_flags_set {
                 opts.project_type = true;
-                opts.framework = true;
                 opts.entry_points = true;
-                opts.test_layout = true;
-                opts.config_files = true;
             }
 
             let cache = CacheManager::new(".");
             let context = crate::context::generate_context(&cache, &opts)?;
 
+            let hint = if no_flags_set {
+                "\n\n---\nHint: this is the minimal orientation view. Pass any combination of these flags for more detail: structure, file_types, framework, test_layout, config_files."
+            } else {
+                ""
+            };
+
             Ok(json!({
                 "content": [{
                     "type": "text",
-                    "text": context
+                    "text": format!("{}{}", context, hint)
+                }]
+            }))
+        }
+        "check_index_status" => {
+            let cache = CacheManager::new(".");
+
+            if !cache.exists() {
+                let result = json!({
+                    "status": "missing",
+                    "action_required": "rfx index"
+                });
+                return Ok(json!({
+                    "content": [{
+                        "type": "text",
+                        "text": serde_json::to_string(&result)?
+                    }]
+                }));
+            }
+
+            let engine = QueryEngine::new(cache);
+            let (status, _can_trust, warning) = engine.get_index_status()?;
+
+            let status_str = match status {
+                IndexStatus::Fresh => "fresh",
+                IndexStatus::Stale => "stale",
+            };
+
+            let result = if let Some(w) = warning {
+                let mut obj = json!({
+                    "status": status_str,
+                    "reason": w.reason,
+                    "action_required": w.action_required
+                });
+                if let Some(fm) = w.files_modified {
+                    obj["files_modified"] = json!(fm);
+                }
+                obj
+            } else {
+                json!({ "status": status_str })
+            };
+
+            Ok(json!({
+                "content": [{
+                    "type": "text",
+                    "text": serde_json::to_string(&result)?
+                }]
+            }))
+        }
+        "find_references" => {
+            let pattern = arguments["pattern"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("Missing pattern"))?
+                .to_string();
+
+            let lang = arguments["lang"].as_str().map(|s| s.to_string());
+            let kind = arguments["kind"].as_str().map(|s| s.to_string());
+            let limit = arguments["limit"].as_u64().map(|n| n as usize);
+            let offset = arguments["offset"].as_u64().map(|n| n as usize);
+            let glob_patterns: Vec<String> = arguments["glob"]
+                .as_array()
+                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
+                .unwrap_or_default();
+            let exclude_patterns: Vec<String> = arguments["exclude"]
+                .as_array()
+                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
+                .unwrap_or_default();
+            let force = arguments["force"].as_bool().unwrap_or(false);
+
+            let language = parse_language(lang);
+            let parsed_kind = parse_symbol_kind(kind);
+
+            // Search 1: Find symbol definition (symbols_mode=true, small cap)
+            let def_filter = QueryFilter {
+                language,
+                kind: parsed_kind,
+                use_ast: false,
+                use_regex: false,
+                limit: Some(5),
+                symbols_mode: true,
+                expand: false,
+                file_pattern: None,
+                exact: false,
+                use_contains: false,
+                timeout_secs: 30,
+                glob_patterns: glob_patterns.clone(),
+                exclude_patterns: exclude_patterns.clone(),
+                paths_only: false,
+                offset: None,
+                force,
+                suppress_output: true,
+                include_dependencies: false,
+                ..Default::default()
+            };
+
+            let cache = CacheManager::new(".");
+            let engine = QueryEngine::new(cache);
+            let def_response = engine.search_with_metadata(&pattern, def_filter)?;
+
+            // Extract first definition as a compact object (reuse MatchResult's Serialize impl)
+            const MAX_PREVIEW_LENGTH: usize = 100;
+            let definition: Option<serde_json::Value> = def_response.results.first().and_then(|fg| {
+                fg.matches.first().map(|m| {
+                    let mut def_obj = serde_json::to_value(m).unwrap_or(json!({}));
+                    if let serde_json::Value::Object(ref mut map) = def_obj {
+                        map.insert("path".to_string(), json!(fg.path.clone()));
+                        // Truncate preview if present
+                        if let Some(preview) = map.get("preview").and_then(|v| v.as_str()) {
+                            let truncated = crate::cli::truncate_preview(preview, MAX_PREVIEW_LENGTH);
+                            map.insert("preview".to_string(), json!(truncated));
+                        }
+                    }
+                    def_obj
+                })
+            });
+
+            // Search 2: Find all textual references (symbols_mode=false)
+            let ref_filter = QueryFilter {
+                language,
+                kind: None,
+                use_ast: false,
+                use_regex: false,
+                limit: limit.or(Some(100)),
+                symbols_mode: false,
+                expand: false,
+                file_pattern: None,
+                exact: false,
+                use_contains: false,
+                timeout_secs: 30,
+                glob_patterns,
+                exclude_patterns,
+                paths_only: false,
+                offset,
+                force,
+                suppress_output: true,
+                include_dependencies: false,
+                ..Default::default()
+            };
+
+            let ref_response = engine.search_with_metadata(&pattern, ref_filter)?;
+
+            // Flatten references to compact {path, line, preview} array
+            let references: Vec<serde_json::Value> = ref_response.results.iter()
+                .flat_map(|fg| {
+                    fg.matches.iter().map(move |m| {
+                        json!({
+                            "path": fg.path,
+                            "line": m.span.start_line,
+                            "preview": crate::cli::truncate_preview(&m.preview, MAX_PREVIEW_LENGTH)
+                        })
+                    })
+                })
+                .collect();
+
+            let total_references = ref_response.pagination.total;
+
+            let response = json!({
+                "status": ref_response.status,
+                "definition": definition,
+                "references": references,
+                "total_references": total_references,
+                "pagination": ref_response.pagination,
+            });
+
+            Ok(json!({
+                "content": [{
+                    "type": "text",
+                    "text": serde_json::to_string(&response)?
                 }]
             }))
         }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1690,7 +1690,6 @@ fn handle_call_tool(params: Option<Value>) -> Result<Value> {
             let def_response = engine.search_with_metadata(&pattern, def_filter)?;
 
             // Extract first definition as a compact object (reuse MatchResult's Serialize impl)
-            const MAX_PREVIEW_LENGTH: usize = 100;
             let definition: Option<serde_json::Value> = def_response.results.first().and_then(|fg| {
                 fg.matches.first().map(|m| {
                     let mut def_obj = serde_json::to_value(m).unwrap_or(json!({}));
@@ -1698,7 +1697,7 @@ fn handle_call_tool(params: Option<Value>) -> Result<Value> {
                         map.insert("path".to_string(), json!(fg.path.clone()));
                         // Truncate preview if present
                         if let Some(preview) = map.get("preview").and_then(|v| v.as_str()) {
-                            let truncated = crate::cli::truncate_preview(preview, MAX_PREVIEW_LENGTH);
+                            let truncated = crate::cli::truncate_preview(preview, DEFAULT_MCP_PREVIEW_LENGTH);
                             map.insert("preview".to_string(), json!(truncated));
                         }
                     }
@@ -1738,7 +1737,7 @@ fn handle_call_tool(params: Option<Value>) -> Result<Value> {
                         json!({
                             "path": fg.path,
                             "line": m.span.start_line,
-                            "preview": crate::cli::truncate_preview(&m.preview, MAX_PREVIEW_LENGTH)
+                            "preview": crate::cli::truncate_preview(&m.preview, DEFAULT_MCP_PREVIEW_LENGTH)
                         })
                     })
                 })

--- a/src/models.rs
+++ b/src/models.rs
@@ -386,6 +386,9 @@ pub struct IndexWarning {
     pub reason: String,
     /// Command to run to fix the issue
     pub action_required: String,
+    /// Number of files detected as modified (only set for mtime-based staleness)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files_modified: Option<u32>,
     /// Additional context (git branch info, etc.)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<IndexWarningDetails>,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -2161,7 +2161,7 @@ impl QueryEngine {
     ///
     /// Returns (status, can_trust_results, warning) tuple for JSON output.
     /// This is optimized for AI agents to detect staleness and auto-reindex.
-    fn get_index_status(&self) -> Result<(IndexStatus, bool, Option<IndexWarning>)> {
+    pub fn get_index_status(&self) -> Result<(IndexStatus, bool, Option<IndexWarning>)> {
         let root = self.cache.workspace_root();
 
         // Check git state if in a git repo
@@ -2172,6 +2172,7 @@ impl QueryEngine {
                     let warning = IndexWarning {
                         reason: format!("Branch '{}' has not been indexed", current_branch),
                         action_required: "rfx index".to_string(),
+                        files_modified: None,
                         details: Some(IndexWarningDetails {
                             current_branch: Some(current_branch),
                             indexed_branch: None,
@@ -2194,6 +2195,7 @@ impl QueryEngine {
                                 &current_commit[..7]
                             ),
                             action_required: "rfx index".to_string(),
+                            files_modified: None,
                             details: Some(IndexWarningDetails {
                                 current_branch: Some(current_branch.clone()),
                                 indexed_branch: Some(current_branch.clone()),
@@ -2234,6 +2236,7 @@ impl QueryEngine {
                             let warning = IndexWarning {
                                 reason: format!("{} of {} sampled files modified", changed, checked),
                                 action_required: "rfx index".to_string(),
+                                files_modified: Some(changed as u32),
                                 details: Some(IndexWarningDetails {
                                     current_branch: Some(current_branch.clone()),
                                     indexed_branch: Some(branch_info.branch.clone()),


### PR DESCRIPTION
Adds docs/mcp-tool-cheatsheet.md — a goal-first decision tree covering
all 15 MCP tools organized by agent intent (find location, find definition,
understand file, understand codebase, maintain index). Includes a tiered
workflow example (list_locations → search_code → expand) and a quick
reference table with cost/speed tiers.

Links added in CLAUDE.md (critical tool selection section) and
docs/ai-agent-integration.md.

Co-Authored-By: Paperclip <noreply@paperclip.ing>