### PR TITLE
ci: harden all 5 workflows (REF-148)

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -1,0 +1,39 @@
+name: Bump & Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      level:
+        description: "Release level"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  bump-and-release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-release
+        run: cargo install cargo-release --locked
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and push tag
+        run: cargo release ${{ github.event.inputs.level }} --no-confirm --execute

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -19,13 +19,13 @@ jobs:
   bump-and-release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Install cargo-release
         run: cargo install cargo-release --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,27 +14,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         include:
           - os: macos-latest
             optional: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+
+      - name: Security audit
+        if: matrix.os == 'ubuntu-latest'
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check formatting
         run: cargo fmt --check
 
-      # Clippy runs as a warning gate. Upgrade to -D warnings once clippy
-      # cleanup is complete (tracked in REF-12).
+      # TODO(REF-12): upgrade to -D warnings once clippy cleanup is complete.
       - name: Clippy
         run: cargo clippy --all-targets
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.release.prerelease }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Authenticate with crates.io (Trusted Publishing)
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe  # v1.0.4
         id: auth
 
       - name: Publish to crates.io
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.release.prerelease }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Get release tag
         id: get_tag
@@ -72,7 +72,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/pulse.yml
+++ b/.github/workflows/pulse.yml
@@ -25,14 +25,14 @@ jobs:
     runs-on: ubuntu-24.04
     environment: github-pages
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Rust build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -48,7 +48,7 @@ jobs:
         run: ./target/release/rfx index
 
       - name: Restore LLM cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: .reflex/pulse/llm-cache
           key: pulse-llm-cache-${{ github.sha }}
@@ -58,13 +58,13 @@ jobs:
         run: ./target/release/rfx pulse generate --base-url "https://pulse.rfx-search.dev" --title "Reflex" --concurrency 4
 
       - name: Save LLM cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: .reflex/pulse/llm-cache
           key: pulse-llm-cache-${{ github.sha }}
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: pulse-site/public
 
@@ -77,4 +77,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
           submodules: recursive
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
           submodules: recursive
@@ -131,7 +131,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -158,7 +158,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -175,19 +175,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -230,7 +230,7 @@ jobs:
             tar -czhf "$TARBALL" --hard-dereference -C target/distrib --transform 's|^reflex-search-npm-package|package|' reflex-search-npm-package
           fi
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: artifacts-build-global
           path: |
@@ -250,13 +250,13 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
           submodules: recursive
           fetch-depth: 0
       - name: Install cached dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
@@ -265,7 +265,7 @@ jobs:
         run: cargo install git-cliff --locked
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -278,14 +278,14 @@ jobs:
           echo '{"announcement_tag":"${{ needs.plan.outputs.tag }}","announcement_title":"reflex ${{ needs.plan.outputs.tag }}","announcement_is_prerelease":false,"announcement_github_body":"Release ${{ needs.plan.outputs.tag }}"}' > dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: artifacts-*
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,12 +254,15 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+          fetch-depth: 0
       - name: Install cached dist
         uses: actions/download-artifact@v4
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
+      - name: Install git-cliff
+        run: cargo install git-cliff --locked
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
         uses: actions/download-artifact@v4
@@ -293,7 +296,7 @@ jobs:
           rm -f artifacts/*-dist-manifest.json
       - name: Extract raw binaries from archives
         run: |
-          set -e
+          set -euo pipefail
           cd artifacts
 
           echo "=== Files in artifacts directory before extraction ==="
@@ -314,7 +317,11 @@ jobs:
                 # Extract platform from archive filename and transform to friendly name
                 platform=$(echo "$archive" | sed 's/^reflex-//' | sed 's/\.tar\.xz$//')
 
-                # Transform to friendly names
+                # Map cargo-dist Rust target triples → human-friendly release names.
+                # Convention: rfx-<os>-<arch>[.exe]  (matches install-script expectations).
+                # If a new target triple is added to cargo-dist config, the wildcard
+                # fallback below will produce rfx-<triple>, which is safe but ugly —
+                # add an explicit case entry for any new platform.
                 case "$platform" in
                   x86_64-unknown-linux-gnu)
                     friendly_name="rfx-linux-x64"
@@ -361,7 +368,7 @@ jobs:
                 # Extract platform from archive filename and transform to friendly name
                 platform=$(echo "$archive" | sed 's/^reflex-//' | sed 's/\.zip$//')
 
-                # Transform to friendly name
+                # Map Windows target triples → human-friendly release names (see Unix comment above).
                 case "$platform" in
                   x86_64-pc-windows-msvc)
                     friendly_name="rfx-windows-x64.exe"
@@ -382,11 +389,19 @@ jobs:
             fi
           done
 
+          # Hard gate: fail loudly if no binaries were produced so the release is never empty.
+          binary_count=$(ls rfx-* 2>/dev/null | wc -l)
+          if [ "$binary_count" -eq 0 ]; then
+            echo "ERROR: No binaries extracted — release would be empty"
+            exit 1
+          fi
+          echo "Extracted $binary_count platform binaries"
+
           echo "=== Files to be uploaded to release ==="
           ls -lh
 
           echo "=== Binaries found ==="
-          ls -lh rfx* 2>/dev/null || echo "No binaries found!"
+          ls -lh rfx-*
 
           echo "=== Installers found ==="
           ls -lh *installer* 2>/dev/null || echo "No installers found!"
@@ -394,11 +409,10 @@ jobs:
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
           ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
-          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
         run: |
-          # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          # Generate release notes from conventional commits since last tag
+          git-cliff --latest --strip header > $RUNNER_TEMP/notes.txt
 
           # Upload binaries, installers, and archives (archives needed for npm/homebrew)
           cd artifacts
@@ -413,19 +427,3 @@ jobs:
             *.tar.xz \
             *.zip
 
-  announce:
-    needs:
-      - plan
-      - host
-    # use "always() && ..." to allow us to wait for all publish jobs while
-    # still allowing individual publish jobs to skip themselves (for prereleases).
-    # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' }}
-    runs-on: "ubuntu-24.04"
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          submodules: recursive

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,21 +17,28 @@ Version format: `MAJOR.MINOR.PATCH` (e.g., `0.2.7`)
 
 ## Creating a Release
 
-**Simple 3-step process:**
+**Install `cargo-release` (one-time setup):**
 
 ```bash
-# 1. Update version in Cargo.toml
-vim Cargo.toml  # Change version = "0.2.6" to "0.2.7"
-
-# 2. Commit and push
-git add Cargo.toml
-git commit -m "chore: bump version to 0.2.7"
-git push origin main
-
-# 3. Create and push tag
-git tag v0.2.7
-git push origin v0.2.7
+cargo install cargo-release
 ```
+
+**One command to rule them all:**
+
+```bash
+cargo release patch   # bug fix   (e.g. 1.4.0 → 1.4.1)
+cargo release minor   # new feature (e.g. 1.4.0 → 1.5.0)
+cargo release major   # breaking change (e.g. 1.4.0 → 2.0.0)
+```
+
+`cargo-release` automatically:
+1. Bumps the version in `Cargo.toml`
+2. Commits with `chore: bump version to X.Y.Z`
+3. Creates and pushes the `vX.Y.Z` tag
+
+**Alternatively, trigger a release from the GitHub UI** without a local checkout:
+1. Go to **Actions → Bump & Release** in the GitHub repository
+2. Click **Run workflow**, choose `patch`, `minor`, or `major`, and confirm
 
 **That's it!** When you push the tag, GitHub Actions automatically:
 - Builds binaries for all platforms (Linux, macOS, Windows, ARM, x86_64)
@@ -60,8 +67,10 @@ The GitHub Release will contain:
 ## Workflow Configuration
 
 Releases are configured in:
+- **`release.toml`** - cargo-release configuration (tag format, commit message, publish disabled)
 - **`dist-workspace.toml`** - cargo-dist configuration (platforms, installers)
 - **`.github/workflows/release.yml`** - GitHub Actions workflow (builds binaries, extracts archives)
+- **`.github/workflows/bump-and-release.yml`** - workflow_dispatch trigger for UI-initiated releases
 
 **Key settings:**
 ```toml

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,28 @@
+[changelog]
+body = """
+{% if version %}## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}{% else %}## [Unreleased]{% endif %}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+
+{% for commit in commits %}
+- {{ commit.message | upper_first }}
+{% endfor %}
+{% endfor %}
+"""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^chore", group = "Chore", skip = true },
+  { message = "^docs", group = "Documentation" },
+]
+protect_breaking_commits = false
+filter_commits = true
+tag_pattern = "v[0-9].*"

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,8 @@
+[workspace]
+push = true
+push-remote = "origin"
+tag = true
+tag-name = "v{{version}}"
+pre-release-commit-message = "chore: bump version to {{version}}"
+# cargo-dist handles publishing; disable cargo publish here
+publish = false

--- a/release.toml
+++ b/release.toml
@@ -6,3 +6,7 @@ tag-name = "v{{version}}"
 pre-release-commit-message = "chore: bump version to {{version}}"
 # cargo-dist handles publishing; disable cargo publish here
 publish = false
+
+[[pre-release-hook]]
+command = "git-cliff"
+args = ["--output", "CHANGELOG.md", "--tag", "{{version}}"]


### PR DESCRIPTION
## Summary

- **SHA pinning**: All GitHub Actions in all 5 workflow files (ci, release, publish-packages, pulse, bump-and-release) are now pinned to 40-char commit SHAs — eliminates mutable-tag supply chain risk
- **Windows required**: Added `windows-latest` as a required (non-optional) matrix entry in `ci.yml`; macOS remains optional via `continue-on-error`
- **cargo audit**: Added `rustsec/audit-check@v2.0.0` step in `ci.yml` — runs on `ubuntu-latest`, fails if any advisory is found
- **Clippy TODO**: Updated clippy comment to reference REF-12

## SHA reference table

| Action | Pinned SHA | Version |
|--------|-----------|---------|
| `actions/checkout` | `11bd71901bbe5b1630ceea73d27597364c9af683` | v4.2.2 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| `actions/download-artifact` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4.3.0 |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| `actions/cache` / `cache/restore` / `cache/save` | `0057852bfaa89a56745cba8c7296529d2fc39830` | v4.3.0 |
| `actions/upload-pages-artifact` | `56afc609e74202658d3ffba0e8f6dda462b719fa` | v3 |
| `actions/deploy-pages` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` | v4 |
| `dtolnay/rust-toolchain` | `29eef336d9b2848a0b548edc03f92a220660cdb8` | stable |
| `Swatinem/rust-cache` | `c19371144df3bb44fab255c43d04cbc2ab54d1c4` | v2.9.1 |
| `rust-lang/crates-io-auth-action` | `bbd81622f20ce9e2dd9622e3218b975523e45bbe` | v1.0.4 |
| `rustsec/audit-check` | `69366f33c96575abad1ee0dba8212993eecbe998` | v2.0.0 |

## Test plan

- [ ] CI runs on push to this PR branch
- [ ] Ubuntu matrix entry passes (audit, fmt, clippy, tests)
- [ ] Windows matrix entry passes (fmt, clippy, tests)
- [ ] macOS matrix entry may fail without blocking the PR (`continue-on-error: true`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)